### PR TITLE
Adding `--account` option for SLURM jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,27 +5,30 @@ This repository contains scripts to process meteorological datasets in NetCDF fi
 Usage:
   extract-dataset [options...]
 Script options:
-  -d, --dataset				Meteorological forcing dataset of interest
-  -i, --dataset-dir=DIR			The source path of the dataset file(s)
-  -v, --variable=var1[,var2[...]]	Variables to process
-  -o, --output-dir=DIR			Writes processed files to DIR
-  -s, --start-date=DATE			The start date of the data
-  -e, --end-date=DATE			The end date of the data
-  -l, --lat-lims=REAL,REAL		Latitude's upper and lower bounds
-  -n, --lon-lims=REAL,REAL		Longitude's upper and lower bounds
-  -a, --shape-file=PATH			Path to the ESRI shapefile; optional
-  -m, --ensemble=ens1,[ens2[...]]	Ensemble members to process; optional
-  					Leave empty to extract all ensemble members
-  -j, --submit-job			Submit the data extraction process as a job
-					on the SLURM system; optional
-  -k, --no-chunk			No parallelization, recommended for small domains
-  -p, --prefix=STR			Prefix  prepended to the output files
-  -b, --parsable			Parsable SLURM message mainly used
-					for chained job submissions
-  -c, --cache=DIR			Path of the cache directory; optional
-  -E, --email=user@example.com		E-mail user when job starts, ends, and finishes; optional
-  -V, --version				Show version
-  -h, --help				Show this screen and exit
+  -d, --dataset                         Meteorological forcing dataset of interest
+  -i, --dataset-dir=DIR                 The source path of the dataset file(s)
+  -v, --variable=var1[,var2[...]]       Variables to process
+  -o, --output-dir=DIR                  Writes processed files to DIR
+  -s, --start-date=DATE                 The start date of the data
+  -e, --end-date=DATE                   The end date of the data
+  -l, --lat-lims=REAL,REAL              Latitude's upper and lower bounds
+  -n, --lon-lims=REAL,REAL              Longitude's upper and lower bounds 
+  -a, --shape-file=PATH                 Path to the ESRI shapefile; optional
+  -m, --ensemble=ens1,[ens2[...]]       Ensemble members to process; optional
+                                        Leave empty to extract all ensemble members
+  -j, --submit-job                      Submit the data extraction process as a job
+                                        on the SLURM system; optional
+  -k, --no-chunk                        No parallelization, recommended for small domains
+  -p, --prefix=STR                      Prefix  prepended to the output files
+  -b, --parsable                        Parsable SLURM message mainly used
+                                        for chained job submissions
+  -c, --cache=DIR                       Path of the cache directory; optional
+  -E, --email=user@example.com          E-mail user when job starts, ends, or               
+                                        fails; optional
+  -u, --account                         Digital Research Alliance of Canada's sponsor's
+                                        account name; optional, defaults to \'rpp-kshook`'  
+  -V, --version                         Show version 
+  -h, --help                            Show this screen and exit
 
 ```
 # Available Datasets

--- a/extract-dataset.sh
+++ b/extract-dataset.sh
@@ -70,7 +70,10 @@ Script options:
   -b, --parsable			Parsable SLURM message mainly used
 					for chained job submissions
   -c, --cache=DIR			Path of the cache directory; optional
-  -E, --email=user@example.com		E-mail user when job starts, ends, and finishes; optional
+  -E, --email=user@example.com		E-mail user when job starts, ends, or
+  					fails; optional
+  -u, --account				Digital Research Alliance of Canada's sponsor's
+  					account name; optional, defaults to \'rpp-kshook`'
   -V, --version				Show version
   -h, --help				Show this screen and exit
 

--- a/extract-dataset.sh
+++ b/extract-dataset.sh
@@ -115,7 +115,7 @@ shopt -s expand_aliases
 # Parsing input arguments
 # =======================
 # argument parsing using getopt - WORKS ONLY ON LINUX BY DEFAULT
-parsedArguments=$(getopt -a -n extract-dataset -o jhVbE:d:i:v:o:s:e:t:l:n:p:c:m:ka: --long submit-job,help,version,parsable,email:,dataset:,dataset-dir:,variable:,output-dir:,start-date:,end-date:,time-scale:,lat-lims:,lon-lims:,prefix:,cache:,ensemble:,no-chunk,shape-file: -- "$@")
+parsedArguments=$(getopt -a -n extract-dataset -o jhVbE:d:i:v:o:s:e:t:l:n:p:c:m:ka:u: --long submit-job,help,version,parsable,email:,dataset:,dataset-dir:,variable:,output-dir:,start-date:,end-date:,time-scale:,lat-lims:,lon-lims:,prefix:,cache:,ensemble:,no-chunk,shape-file:,account: -- "$@")
 validArguments=$?
 # check if there is no valid options
 if [ "$validArguments" != "0" ]; then
@@ -152,6 +152,7 @@ do
     -p | --prefix)	  prefixStr="$2"       ; shift 2 ;; # required
     -b | --parsable)	  parsable=true	       ; shift   ;; # optional
     -c | --cache)	  cache="$2"	       ; shift 2 ;; # optional
+    -u | --account)       account="$2"         ; shift 2 ;; # optional
     -a | --shape-file)    shapefile="$2"       ; shift 2 ;; # optional
 
     # -- means the end of the arguments; drop this, and break out of the while loop
@@ -198,6 +199,12 @@ if [[ -n $parsable ]]; then
   parsable="--parsable"
 else
   parsable=""
+fi
+
+# if account is not provided, use `rpp-kshook` as default
+if [[ -z $account ]]; then
+  account="rpp-kshook"
+  echo "$(basename $0): WARNING! --account not provided, using \`rpp-kshook\` by default."
 fi
 
 # if shapefile is provided extract the extents from it
@@ -416,7 +423,7 @@ call_processing_func () {
 	#SBATCH --array=0-$jobArrLen
 	#SBATCH --cpus-per-task=4
 	#SBATCH --nodes=1
-	#SBATCH --account=rpp-kshook
+	#SBATCH --account=$account
 	#SBATCH --time=04:00:00
 	#SBATCH --mem=8000M
 	#SBATCH --job-name=DATA_${scriptName}


### PR DESCRIPTION
Addressing #30 

This is an interim solution to enable DRA users from various accounts to use the `datatool` scripts. In the near future, the script should be able to deal with various schedulers, and file/folder structures.

Reported-by: Sujata Budhathoki <sujata.budhathoki@ec.gc.ca>