### PR TITLE
Resolving #28 issue

### DIFF
--- a/scripts/conus_i/README.md
+++ b/scripts/conus_i/README.md
@@ -2,6 +2,13 @@
 
 In this file, the details of the dataset is explained.
 
+> [!CAUTION]
+> `WRF-CONUSI` dataset needs extensive I/O operations in the `cache`
+> directory. So, in case of submitting `SLURM` jobs, it is recommended to
+> use the `$SLURM_TMPDIR` directory as `cache`. This can be provided to
+> the main `extract-dataset.sh` script using the `--cache='$SLURM_TMPDIR'`
+> option. Please be mindful of **single** quotation marks for the argument.
+
 ## Location of Dataset Files
 The `WRF-CONUSI` simulation outputs are located under the following directory accessible from Compute Canada (CC) Graham Cluster:
 ```

--- a/scripts/conus_ii/README.md
+++ b/scripts/conus_ii/README.md
@@ -10,6 +10,8 @@ In this file, the details of the dataset is explained.
 > directory. So, in case of submitting `SLURM` jobs, it is recommended to
 > use the `$SLURM_TMPDIR` directory as `cache`. This can be provided to
 > the main `extract-dataset.sh` script using the `--cache='$SLURM_TMPDIR'`
+> option. Please be mindful of **single** quotation marks for the argument.
+
 ## Location of Dataset Files
 
 The `WRF-CONUSII` simulation outputs are located under the following directory accessible from Compute Canada (CC) Graham Cluster:

--- a/scripts/conus_ii/README.md
+++ b/scripts/conus_ii/README.md
@@ -6,7 +6,7 @@ In this file, the details of the dataset is explained.
 > It must be noted that the `WRF-CONUSII` dataset are in `.tar` format and the script untars the files automatically. 
 
 > [!CAUTION]
-> `WRF-CONUSI` dataset needs extensive I/O operations in the `cache`
+> `WRF-CONUSII` dataset needs extensive I/O operations in the `cache`
 > directory. So, in case of submitting `SLURM` jobs, it is recommended to
 > use the `$SLURM_TMPDIR` directory as `cache`. This can be provided to
 > the main `extract-dataset.sh` script using the `--cache='$SLURM_TMPDIR'`

--- a/scripts/conus_ii/README.md
+++ b/scripts/conus_ii/README.md
@@ -2,8 +2,16 @@
 
 In this file, the details of the dataset is explained.
 
-:warning: It must be noted that the `WRF-CONUSII` dataset are in `.tar` format and the script untars the files automatically. 
+> [!WARNING]
+> It must be noted that the `WRF-CONUSII` dataset are in `.tar` format and the script untars the files automatically. 
+
+> [!CAUTION]
+> `WRF-CONUSI` dataset needs extensive I/O operations in the `cache`
+> directory. So, in case of submitting `SLURM` jobs, it is recommended to
+> use the `$SLURM_TMPDIR` directory as `cache`. This can be provided to
+> the main `extract-dataset.sh` script using the `--cache='$SLURM_TMPDIR'`
 ## Location of Dataset Files
+
 The `WRF-CONUSII` simulation outputs are located under the following directory accessible from Compute Canada (CC) Graham Cluster:
 ```
 /project/rpp-kshook/Model_Output/wrf-conus/CONUSII/hist


### PR DESCRIPTION
The adds further note about using specific `cache` directory with `WRF-CONUS` datasets. Usually, `$SLURM_TMPDIR` points to a local storage for each `node` while using `SLURM` scheduler. Mostly, the nodes provided are in the form of Solid State Drives (SSDs) which facilitates massive I/O operations.

Therefore, users are encouraged to use this method while dealing these type of datasets.

Resolving #28.