### PR TITLE
Leap days in future runs or non-existent

### DIFF
--- a/scripts/gwf-ncar-conus_ii/conus_ii.sh
+++ b/scripts/gwf-ncar-conus_ii/conus_ii.sh
@@ -437,6 +437,14 @@ for yr in $yearsRange; do
       # current timestamp formatted to conform to CONUSII naming convention
       toDateFormatted=$(date --date "$toDate" "+$format")
 
+      # ignore leap days
+      day=$(date --date "$toDate" "+%m%d")
+      if [[ "$day" == "0229" ]]; then
+        toDate=$(date --date "$toDate 1hours") # current time-step
+        toDateUnix=$(date --date "$toDate" +"%s") # current UNIX EPOCH
+        continue
+      fi
+
       # copy files to $cache
       cp "${datasetDir}/${yr}/${fileStruct}_${toDateFormatted}" \
          "${cacheDir}/${yr}/${fileStruct}_${toDateFormatted}"
@@ -469,10 +477,10 @@ for yr in $yearsRange; do
            -d "$lonVar","$lonLimsIdx" \
            "$cacheDir/$yr/$f2" "$cacheDir/$yr/$f2"; do
 
-	      echo "$(basename $0): Process killed: restarting process" >$2
+        echo "$(basename $0): Process killed: restarting process" >$2
 	      sleep 5;
       done
-    
+ 
     done
 
     # increment time-step by one unit
@@ -498,7 +506,6 @@ for yr in $yearsRange; do
   files=($cacheDir/$yr/*)
   # sorting files to make sure the time-series is correct
   IFS=$'\n' files=($(sort <<<"${files[*]}")); unset IFS
-
 
   # check the $timeScale variable
   case "${timeScale,,}" in


### PR DESCRIPTION
Addressing #59:

Another difference between historical and future runs of GWF-NCAR WRF-CONUS-II runs are the leap days. While in historical runs leap days exists, in future runs these days are non-existent.

This commit takes care of this difference in data processing and extraction of this dataset.

Reported-by: Kasra Keshavarz <kasra.keshavarz1@ucalgary.ca>